### PR TITLE
Fixed Command Injection

### DIFF
--- a/lib/virtualbox.js
+++ b/lib/virtualbox.js
@@ -2,7 +2,7 @@
 
 // @todo use a promise library instead of so many callbacks
 
-var exec = require('child_process').exec,
+var execFile = require('child_process').execFile,
   host_platform = process.platform,
   logging = require('./logging'),
   vBoxManageBinary,
@@ -40,7 +40,9 @@ exec(vBoxManageBinary + ' --version', function(error, stdout, stderr) {
 });
 
 function command(cmd, callback) {
-  exec(cmd, function(err, stdout, stderr) {
+  var cmd_bin  = cmd.split(' ')[0];
+  var cmd_args = cmd.replace(cmd_bin, '');
+  execFile(cmd_bin, cmd_args, function(err, stdout, stderr) {
 
     if (!err && stderr && cmd.indexOf("pause") !== -1 && cmd.indexOf("savestate") !== -1) {
       err = new Error(stderr);


### PR DESCRIPTION
:gear: **Fix:**

The mitigation is implemented by using `execFile()` instead of `exec()` which takes input as an array preventing the ability to achieve a Command Injection Vulnerability as it escapes concatenated shell commands by default.